### PR TITLE
chore: bump dependency versions to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ uv sync --extras dev
 pytest tests/integration
 ```
 
-To change the version of infrahub being used you can use an environment variable: `export INFRAHUB_TESTING_IMAGE_VERSION=1.3.0`.
+To change the version of infrahub being used you can use an environment variable: `export INFRAHUB_TESTING_IMAGE_VERSION=1.9.6`.

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -6,21 +6,18 @@ authors = []
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
 dependencies = [
-    "infrahub-sdk[all]>=1.13.1",
-    "invoke>=2.2.0",
+    "infrahub-sdk[all]>=1.20.1",
+    "invoke>=3.0.3",
 ]
 
 [dependency-groups]
 dev = [
-    "infrahub-testcontainers>=1.3.0",
-    "pytest>=8.4.1",
-    "pytest-asyncio>=1.0.0",
-    "ruff>=0.12.0",
-    "mypy>=1.17.1",
-    "pytest>=8.4.1",
-    "pytest-asyncio>=1.0.0",
-    "ruff>=0.12.0",
-    "yamllint>=1.37.1",
+    "infrahub-testcontainers>=1.9.6",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.4.0",
+    "ruff>=0.15.14",
+    "mypy>=2.1.0",
+    "yamllint>=1.38.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- `infrahub-sdk` `1.13.1` → `1.20.1`
- `invoke` `2.2.0` → `3.0.3`
- `infrahub-testcontainers` `1.3.0` → `1.9.6` (aligned with latest Infrahub v1.9.6)
- `pytest` `8.4.1` → `9.0.3`
- `pytest-asyncio` `1.0.0` → `1.4.0`
- `ruff` `0.12.0` → `0.15.14`
- `mypy` `1.17.1` → `2.1.0`
- `yamllint` `1.37.1` → `1.38.0`
- Remove duplicate `pytest`, `pytest-asyncio`, and `ruff` entries in dev dependencies
- Update README example version `1.3.0` → `1.9.6`

## Test plan

- [x] `copier copy` from branch produces correct `pyproject.toml` with updated versions
- [x] `uv sync --all-packages` resolves and installs all 104 packages cleanly with no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)