### PR TITLE
docs: stop claiming Spec Kit is pre-configured in the generated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To start infrahub simply use `invoke start`
 
 ## Spec-Driven Development
 
-This repository includes [GitHub Spec Kit](https://github.com/github/spec-kit) pre-configured with Infrahub best practices. Spec-driven development uses natural-language specifications as the primary development artifact — your AI agent generates plans, tasks, and working code from those specs.
+This repository is set up to work with [GitHub Spec Kit](https://github.com/github/spec-kit) and the Infrahub preset, which brings Infrahub best practices to spec-driven development. Install them with the prerequisites below. Spec-driven development uses natural-language specifications as the primary development artifact — your AI agent generates plans, tasks, and working code from those specs.
 
 Infrahub skills give your AI agent domain-specific knowledge about Infrahub's schema design, data modeling, validation checks, generators, transforms, and more. When installed, the agent automatically uses the right skill at each workflow step — for example, invoking the schema-creator skill when designing data models, or the check-creator skill when writing validation logic. Without skills installed, the agent falls back to the general conventions in the constitution, but loses the detailed guidance that produces correct Infrahub artifacts on the first try.
 


### PR DESCRIPTION
## The contradiction

`README.md` currently makes two claims that cannot both be true.

Line 34 says Spec Kit is already there:

> This repository includes [GitHub Spec Kit](https://github.com/github/spec-kit) pre-configured with Infrahub best practices.

Then the Prerequisites section, ~15 lines later, tells the reader to install it themselves:

> 2. **Install the Specify CLI and agent commands**:
>
>    Install the CLI:
>    ```bash
>    uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
>    ```
>
>    Initialize speckit in the repository:
>    ```bash
>    # Replace <integration> with: claude, copilot, cursor-agent, gemini, windsurf, etc.
>    specify init --here --integration <integration> --force
>    ```
>
> 3. **Add the Infrahub speckit preset**:
>
>    ```bash
>    specify preset add --from https://github.com/opsmill/infrahub-speckit/archive/refs/heads/main.zip
>    ```

## Which one is right

The install instructions are right; the "includes / pre-configured" sentence is stale.

- `3d94aea` ("feat: remove `.specify` from template — installed by `specify init` + `preset add`") deleted the vendored `.specify/` tree (13 files, extension + preset + constitution + 6 spec templates) and trimmed the README's "Key Files" and "Constitution" subsections — but left the opening sentence untouched.
- At `v0.0.3` the template still carried `.specify/` (`git ls-tree -d v0.0.3 .specify` resolves). At `v0.0.5` / current `main` it does not.
- Scaffolding a fresh repo from `main` with every feature enabled (`uvx copier copy --trust --defaults gh:opsmill/infrahub-template .`, `_commit: v0.0.5`) produces no `.specify/` directory. Generated top level: `.claude/`, `.copier-answers.yml`, `.gitignore`, `.graphqlrc.yml`, `.infrahub.yml`, `.vscode/`, `.yamllint.yml`, `README.md`, `infrahubctl.toml`, `pyproject.toml`, `tasks.py`, plus `lib/ generators/ menus/ objects/ queries/ schemas/ scripts/ transforms/ tests/`.

So a user reading the current README is told the tooling is already configured, finds nothing configured, and only the steps they were implicitly invited to skip actually work.

## The change

One sentence, reworded to describe the repository as *ready to work with* Spec Kit and the Infrahub preset, and to point at the install steps that follow:

```diff
-This repository includes [GitHub Spec Kit](https://github.com/github/spec-kit) pre-configured with Infrahub best practices. Spec-driven development uses …
+This repository is set up to work with [GitHub Spec Kit](https://github.com/github/spec-kit) and the Infrahub preset, which brings Infrahub best practices to spec-driven development. Install them with the prerequisites below. Spec-driven development uses …
```

Note this `README.md` is both the template repo's own README and the file copier renders into every generated repository (the template root is the repo root and the file carries no `.jinja` suffix, so it is copied verbatim), so the single edit fixes both.

Docs only — no template logic, no `copier.yml` change, no `.specify/` directory added, no behaviour impact. Install instructions and workflow explanation are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
