### PR TITLE
fix: make the invoke tasks work as documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,8 @@ uv sync --extras dev
 pytest tests/integration
 ```
 
-To change the version of infrahub being used you can use an environment variable: `export INFRAHUB_TESTING_IMAGE_VERSION=1.9.6`.
+To change the version of Infrahub used by the tests, set the variable the SDK reads:
+`export INFRAHUB_TESTING_IMAGE_VER=<version>`.
+
+To pin the version of the local docker stack instead, set `VERSION` (or the equivalent
+`INFRAHUB_IMAGE_VER`) before `invoke start`: `export VERSION=<version>`.

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -46,8 +46,6 @@ exclude = [
 
 
 [tool.ruff.lint]
-preview = true
-
 task-tags = ["FIXME", "TODO", "XXX"]
 
 select = ["ALL"]

--- a/tasks.py
+++ b/tasks.py
@@ -123,11 +123,27 @@ def lint_yaml(ctx: Context) -> None:
         ctx.run(exec_cmd, pty=True)
 
 
+# mypy needs explicit targets. Which of these a repository actually has depends on
+# the copier answers — lib/, scripts/, tests/, generators/ and transforms/ are all
+# optional — and mypy errors out on a directory containing no Python, so only the
+# targets that exist and hold Python are passed through.
+MYPY_TARGETS = ("tasks.py", "lib", "scripts", "tests", "generators", "transforms")
+
+
+def _mypy_targets() -> list[str]:
+    targets = []
+    for name in MYPY_TARGETS:
+        path = MAIN_DIRECTORY_PATH / name
+        if path.is_file() or (path.is_dir() and any(path.rglob("*.py"))):
+            targets.append(name)
+    return targets
+
+
 @task
 def lint_mypy(ctx: Context) -> None:
     """Run Linter to check all Python files."""
     print(" - Check code with mypy")
-    exec_cmd = "mypy --show-error-codes infrahub_sdk"
+    exec_cmd = f"mypy --show-error-codes {' '.join(_mypy_targets())}"
     with ctx.cd(MAIN_DIRECTORY_PATH):
         ctx.run(exec_cmd, pty=True)
 

--- a/tasks.py
+++ b/tasks.py
@@ -6,10 +6,19 @@ from pathlib import Path
 import httpx
 from invoke import Context, task
 
-# If no version is indicated, we will take the latest
-VERSION = os.getenv("INFRAHUB_IMAGE_VER", None)
+# The compose file resolves the Infrahub image tag from $VERSION, so a pin has to
+# be exported into the compose environment rather than merely read here.
+# INFRAHUB_IMAGE_VER is the name this template has always documented; $VERSION is
+# what compose itself reads, so both are accepted. When neither is set, nothing is
+# forwarded and the compose file's own default applies.
+INFRAHUB_VERSION = os.getenv("VERSION") or os.getenv("INFRAHUB_IMAGE_VER")
 CURRENT_DIRECTORY = Path(__file__).resolve()
 MAIN_DIRECTORY_PATH = Path(__file__).parent
+
+
+def _compose_env() -> dict[str, str]:
+    """Environment for docker compose, carrying the Infrahub image pin if one is set."""
+    return {"VERSION": INFRAHUB_VERSION} if INFRAHUB_VERSION else {}
 
 
 @task
@@ -18,7 +27,7 @@ def start(context: Context) -> None:
     Start the services using docker-compose in detached mode.
     """
     download_compose_file(context, override=False)
-    context.run("docker compose up -d")
+    context.run("docker compose up -d", env=_compose_env())
 
 
 @task
@@ -27,7 +36,7 @@ def destroy(context: Context) -> None:
     Stop and remove containers, networks, and volumes.
     """
     download_compose_file(context, override=False)
-    context.run("docker compose down -v")
+    context.run("docker compose down -v", env=_compose_env())
 
 
 @task
@@ -36,7 +45,7 @@ def stop(context: Context) -> None:
     Stop containers and remove networks.
     """
     download_compose_file(context, override=False)
-    context.run("docker compose down")
+    context.run("docker compose down", env=_compose_env())
 
 
 @task(help={"component": "Optional name of a specific service to restart."})
@@ -46,10 +55,10 @@ def restart(context: Context, component: str = "") -> None:
     """
     download_compose_file(context, override=False)
     if component:
-        context.run(f"docker compose restart {component}")
+        context.run(f"docker compose restart {component}", env=_compose_env())
         return
 
-    context.run("docker compose restart")
+    context.run("docker compose restart", env=_compose_env())
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -180,11 +180,18 @@ def _overwrite_copy(src: Path, dst: Path) -> None:
     shutil.copytree(src, dst)
 
 
-@task(name="schema-library-get")
-def get_schema_library(ctx: Context) -> None:
+@task(
+    name="schema-library-get",
+    help={"ref": "Branch, tag or commit of opsmill/schema-library to fetch. Defaults to main."},
+)
+def get_schema_library(ctx: Context, ref: str = "main") -> None:
     """
     Download base and extensions folders from the opsmill/schema-library repository
     into schema-library/, then copy a subset into schemas/.
+
+    Pass --ref to pin the fetch to a tag or commit, e.g. --ref v1.4.11. Whatever is
+    fetched, the resolved commit is recorded in schema-library/.version so the
+    starting schemas can be traced back to an exact revision later.
     """
     repo_url: str = "https://github.com/opsmill/schema-library.git"
     schema_library_dir: Path = MAIN_DIRECTORY_PATH / "schema-library"
@@ -194,13 +201,25 @@ def get_schema_library(ctx: Context) -> None:
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         repo_path: Path = Path(tmp_dir) / "repo"
-        print("Cloning schema-library repository...")
-        ctx.run(f"git clone --depth 1 {repo_url} {repo_path}", hide=True)
+        print(f"Cloning schema-library repository at {ref}...")
+        # A shallow clone can only target a branch or tag, so fall back to a full
+        # clone and checkout when ref is a commit.
+        shallow = ctx.run(
+            f"git clone --depth 1 --branch {ref} {repo_url} {repo_path}", hide=True, warn=True
+        )
+        if shallow.failed:
+            ctx.run(f"git clone {repo_url} {repo_path}", hide=True)
+            ctx.run(f"git -C {repo_path} checkout {ref}", hide=True)
+
+        commit = ctx.run(f"git -C {repo_path} rev-parse HEAD", hide=True).stdout.strip()
 
         _overwrite_copy(repo_path / "base", schema_library_dir / "base")
         _overwrite_copy(repo_path / "extensions", schema_library_dir / "extensions")
 
-    print(f"Schema library updated at {schema_library_dir}")
+    (schema_library_dir / ".version").write_text(
+        f"repository: {repo_url}\nref: {ref}\ncommit: {commit}\n"
+    )
+    print(f"Schema library updated at {schema_library_dir} ({ref} @ {commit[:12]})")
 
     _overwrite_copy(schema_library_dir / "base", schemas_dir / "base")
     _overwrite_copy(schema_library_dir / "extensions" / "location_minimal", schemas_dir / "location_minimal")

--- a/{% if tests %}tests{% endif %}/integration/conftest.py
+++ b/{% if tests %}tests{% endif %}/integration/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from infrahub_sdk.yaml import SchemaFile
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()

--- a/{% if tests %}tests{% endif %}/integration/test_infrahub.py
+++ b/{% if tests %}tests{% endif %}/integration/test_infrahub.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.protocols import CoreGenericRepository
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
@@ -12,7 +11,7 @@ class TestInfrahub(TestInfrahubDockerClient):
     @pytest.mark.asyncio
     async def test_load_schema(
         self, default_branch: str, client: InfrahubClient, schemas: list[dict]
-    ):
+    ) -> None:
         await client.schema.wait_until_converged(branch=default_branch)
 
         resp = await client.schema.load(


### PR DESCRIPTION
## Summary

Three defects in the generated tooling, found while bootstrapping a repository from this template against a live Infrahub 1.11.0 instance. They share a failure shape: **the documented action appears to work, reports nothing, and does nothing.** None of them are visible to the person they affect.

Kept as three commits so the PR can be reviewed one decision at a time.

## Key Changes

### 1. `invoke lint` could not pass on a freshly scaffolded repository (`cb79a1b`)

Before this change, a scaffold with no user code in it fails its own lint gate:

```
invoke lint-mypy  -> mypy: error: Cannot read file 'infrahub_sdk': No such file or directory
invoke lint-ruff  -> Found 13 errors
```

`lint-mypy` targeted `infrahub_sdk`, a path carried over from the SDK repository that exists in no scaffold, so it aborted without checking anything. Targets are now resolved from what copier actually generated — `lib/`, `scripts/`, `tests/`, `generators/` and `transforms/` are all optional, and mypy errors out on a directory containing no Python, so only present targets holding Python are passed.

Of the 13 ruff findings, **7 came from the config rather than the code**: `preview = true` enabled preview rules that flagged the config's own rule codes and the `noqa` comment in `tasks.py`. Preview rules change between ruff releases, so a template that enables them hands every future scaffold a lint failure written after the template was. Preview is now off. **`select = ["ALL"]` is untouched.**

The remaining findings were real, and in files this template ships: the integration test was missing the return annotation its own `disallow_untyped_defs = true` requires, `tests/integration/` had no `__init__.py` while `tests/` does, and two import blocks were unsorted.

### 2. Both documented image-version pins were silent no-ops (`e8c397d`)

`INFRAHUB_IMAGE_VER` was read into a module-level `VERSION` that no task ever referenced, while the compose file resolves its image tag from `$VERSION` in the environment. Setting the variable this template documents therefore had no effect, and `invoke start` always brought up whatever the published compose file defaulted to. The pin is now forwarded into the compose environment for every task that shells out to compose. `$VERSION` is accepted too, since that is the name compose itself reads.

**When neither is set, nothing is forwarded** and the compose file's own default still applies — this template does not pin a version of its own.

The README told readers to export `INFRAHUB_TESTING_IMAGE_VERSION` to change the version used by the tests. The SDK reads `INFRAHUB_TESTING_IMAGE_VER`, so that was a no-op too, and the example pinned 1.9.6 besides. Corrected to the name the SDK actually reads, without a hard-coded version.

### 3. `schema-library-get` recorded nothing about what it fetched (`ec9e8c4`)

The task shallow-cloned the default branch of `opsmill/schema-library` and copied `base/` and `location_minimal/` into `schemas/`, recording nothing. Two people running it a week apart get different starting schemas, with no way to tell what either got and no way to reproduce a working set once the library moves on.

It now accepts `--ref`, so the fetch can be pinned to a tag or commit, and whatever is fetched it resolves the commit and records it in `schema-library/.version`. The default is still the default branch, so existing invocations behave as before — they just say what they did. A shallow clone can only target a branch or tag, so a commit ref falls back to a full clone and checkout.

**The files copied into `schemas/` are unchanged.** Seeding starter schemas looks intentional; this only makes it auditable.

## Test Plan

Scaffolded a repository from this branch (`copier copy --vcs-ref=fix/invoke-task-defaults`) and ran the real gate against it:

- `ruff check .` → **All checks passed!**
- `mypy --show-error-codes tasks.py tests` → **Success: no issues found in 5 source files**
- `yamllint .` → passes
- Version pin: `VERSION=9.9.9` and `INFRAHUB_IMAGE_VER=8.8.8` each forward correctly; neither set forwards `{}`, leaving the compose default in place.
- `schema-library-get` exercised across all three ref forms — default `main` (recorded `fa16de3f065a`), tag `v1.4.11` (recorded `18a5b32b84fe`), and a raw commit SHA via the full-clone fallback.

## Note for reviewers

The one judgement call is turning `preview` off in commit `cb79a1b`. Ruff's auto-fix for those 7 findings rewrites the config to rule *names* (`"print"`, `"assert"`, `"no-self-use"`) and the `noqa` comment to `# ruff:ignore[unused-function-argument]` — syntax that would tie this template to a very recent ruff. Disabling preview keeps the config portable and stops future ruff releases from breaking scaffolds. If preview rules are wanted deliberately, that commit is the one to push back on, and it is isolated from the other two.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
