### PR TITLE
feat: let the load tasks target a branch

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -52,28 +52,37 @@ def restart(context: Context, component: str = "") -> None:
     context.run("docker compose restart")
 
 
-@task
-def load_menu(ctx: Context) -> None:
+# --- Loading into Infrahub ----------------------------------------------------
+# All three loads are per-branch, so each takes --branch and defaults to the active
+# one. Infrahub applies a schema load as a migration against loaded data the moment
+# it lands, so the recommended workflow is to load onto a branch and merge it through
+# a proposed change. Objects must land on the branch that defines their kinds, and a
+# branch without the menu loaded falls back to the auto-generated sidebar.
+@task(help={"branch": "Infrahub branch to load onto. Defaults to the active branch."})
+def load_menu(ctx: Context, branch: str = "") -> None:
+    """
+    Load the custom navigation menu into Infrahub.
+    """
+    branch_arg = f" --branch {branch}" if branch else ""
+    ctx.run(f"infrahubctl menu load menus/{branch_arg}", pty=True)
+
+
+@task(help={"branch": "Infrahub branch to load onto. Defaults to the active branch."})
+def load_schema(ctx: Context, branch: str = "") -> None:
     """
     Load schemas into InfraHub using infrahubctl.
     """
-    ctx.run("infrahubctl menu load menus/", pty=True)
+    branch_arg = f" --branch {branch}" if branch else ""
+    ctx.run(f"infrahubctl schema load schemas{branch_arg}", pty=True)
 
 
-@task
-def load_schema(ctx: Context) -> None:
-    """
-    Load schemas into InfraHub using infrahubctl.
-    """
-    ctx.run("infrahubctl schema load schemas")
-
-
-@task
-def load_objects(ctx: Context) -> None:
+@task(help={"branch": "Infrahub branch to load onto. Defaults to the active branch."})
+def load_objects(ctx: Context, branch: str = "") -> None:
     """
     Load objects into InfraHub using infrahubctl.
     """
-    ctx.run("infrahubctl object load objects")
+    branch_arg = f" --branch {branch}" if branch else ""
+    ctx.run(f"infrahubctl object load objects{branch_arg}", pty=True)
 
 
 @task


### PR DESCRIPTION
## Summary

Infrahub applies a schema load as a migration against loaded data the moment it lands, so the recommended workflow is to load onto a branch and merge it through a proposed change — that is what gives a preview and a way back. None of the three load tasks could express it: they always hit the active branch, so anyone following the recommended workflow had to abandon the tasks and call `infrahubctl` directly.

## Key Changes

- `load-schema`, `load-menu` and `load-objects` each take `--branch`, **defaulting to the active branch so existing invocations are unaffected.**
- Objects and menus need it as much as the schema does. Objects have to land on the branch that defines their kinds — pointing them at the default branch before the schema is merged simply fails — and a menu is per-branch, so a branch without one falls back to the auto-generated sidebar and looks noticeably different.
- Fixes `load-menu`'s docstring, which described loading schemas.
- Gives `load-schema` and `load-objects` the `pty=True` that `load-menu` already had, so all three stream their progress the same way.

## Test Plan

Verified against a live Infrahub 1.11.0 instance that all three commands accept `--branch` in the trailing position these tasks build:

```
infrahubctl menu load menus/ --branch <name>
infrahubctl schema load schemas --branch <name>
infrahubctl object load objects --branch <name>
```

`ruff check tasks.py` and `mypy tasks.py` both pass. Merges cleanly with `fix/invoke-task-defaults`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
